### PR TITLE
Allow configuring server port via env and add test

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,8 @@
   "author": "Shashank Barsin",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node server.test.js"
   },
   "dependencies": {
     "express": "^4.16.4"

--- a/app/server.js
+++ b/app/server.js
@@ -2,13 +2,16 @@
 
 const express = require('express');
 
-const PORT = 8080;
-const HOST = '0.0.0.0';
+const PORT = process.env.PORT || 8080;
+const HOST = process.env.HOST || '0.0.0.0';
 
 const app = express();
 app.get('/', (req, res) => {
   res.send('Hello world\n');
 });
 
-app.listen(PORT, HOST);
-console.log(`Running on http://${HOST}:${PORT}`);
+const server = app.listen(PORT, HOST, () => {
+  console.log(`Running on http://${HOST}:${PORT}`);
+});
+
+module.exports = server;

--- a/app/server.test.js
+++ b/app/server.test.js
@@ -1,0 +1,31 @@
+const http = require('http');
+const server = require('./server');
+
+server.on('listening', () => {
+  const options = {
+    hostname: 'localhost',
+    port: process.env.PORT || 8080,
+    path: '/',
+    method: 'GET'
+  };
+
+  const req = http.request(options, res => {
+    let data = '';
+    res.on('data', chunk => data += chunk);
+    res.on('end', () => {
+      if (data !== 'Hello world\n') {
+        console.error('Unexpected response:', data);
+        process.exit(1);
+      }
+      server.close();
+    });
+  });
+
+  req.on('error', err => {
+    console.error(err);
+    server.close();
+    process.exit(1);
+  });
+
+  req.end();
+});


### PR DESCRIPTION
## Summary
- make express server respect `PORT` and `HOST` environment variables
- export server to enable programmatic control
- add simple test to verify root endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936146ada083228ed823c11fc50438